### PR TITLE
Hotfix/add soname

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -113,7 +113,7 @@ mmx-backapi-config.h: mmx-backapi-config.h.in
 	    -e "s/@MMXBA_MAX_NUMBER_OF_KEY_PARAMS@/${CONFIG_MMXBA_MAX_NUMBER_OF_KEY_PARAMS}/" mmx-backapi-config.h.in > mmx-backapi-config.h
 	
 $(TARGET_SO): $(OBJECTS) 
-	$(CC) $(OBJECTS) -o $@ $(LDFLAGS)
+	$(CC) -Wl,-soname,$@ $(OBJECTS) -o $@ $(LDFLAGS)
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/include

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,31 +68,31 @@
 #
 ################################################################################
 
-ifeq ($(PREFIX),)
+ifeq ($(strip $(PREFIX)),)
     PREFIX := /usr
 endif
 
-override CC ?= gcc
+CC ?= gcc
 override CFLAGS += -c -fPIC -Wall -std=gnu99
 override LDFLAGS += -shared
 
 # "Max string lenght (param, object names)"
-override CONFIG_MMXBA_MAX_STR_LEN ?= 128
+CONFIG_MMXBA_MAX_STR_LEN ?= 128
 
 # "Max number of GET params"
-override CONFIG_MMXBA_MAX_NUMBER_OF_GET_PARAMS ?= 30
+CONFIG_MMXBA_MAX_NUMBER_OF_GET_PARAMS ?= 30
 
 # "Max number of SET params"
-override CONFIG_MMXBA_MAX_NUMBER_OF_SET_PARAMS ?= 30
+CONFIG_MMXBA_MAX_NUMBER_OF_SET_PARAMS ?= 30
 
 # "Max number of GETALL params"
-override CONFIG_MMXBA_MAX_NUMBER_OF_GETALL_PARAMS ?= 192
+CONFIG_MMXBA_MAX_NUMBER_OF_GETALL_PARAMS ?= 192
 
 # "Max number of added objects"
-override CONFIG_MMXBA_MAX_NUMBER_OF_ADDED_INSTANCES ?= 1
+CONFIG_MMXBA_MAX_NUMBER_OF_ADDED_INSTANCES ?= 1
 
 # "Max number of key params in request to backend"
-override CONFIG_MMXBA_MAX_NUMBER_OF_KEY_PARAMS ?= 4
+CONFIG_MMXBA_MAX_NUMBER_OF_KEY_PARAMS ?= 4
 
 
 SOURCES=$(wildcard *.c)


### PR DESCRIPTION
Add SONAME field into shared library
    
    To be able build this library with Yocto it's needed to add SONAME
    into shared library to allow detect that recipe really provides
    library

Fix "override" usage in make files
    
    Replace
        override VAR ?= default_value
    with
        VAR ?= default_value
    
    Keep for statements
        override VAR += additional_value
